### PR TITLE
improved axios typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,10 +1,45 @@
 import { AxiosInstance } from 'axios';
 
-interface RateLimitedAxiosInstance extends AxiosInstance {}
+export interface RateLimitedAxiosInstance extends AxiosInstance {
+   getMaxRPS(): number,
+   setMaxRPS(rps:number): void,
+   setRateLimitOptions(options: rateLimitOPtions): void,
+   // enable(axios: any): void,
+   // handleRequest(request:any):any,
+   // handleResponse(response: any): any,   
+   // push(requestHandler:any):any,
+   // shiftInitial():any,
+   // shift():any
+}
 
-declare function axiosRateLimit(
+type rateLimitOPtions = { maxRequests?: number, perMilliseconds?: number, maxRPS?:number };
+
+ /**
+  * Apply rate limit to axios instance.
+  *
+  * @example
+  *   import axios from 'axios';
+  *   import rateLimit from 'axios-rate-limit';
+  *
+  *   // sets max 2 requests per 1 second, other will be delayed
+  *   // note maxRPS is a shorthand for perMilliseconds: 1000, and it takes precedence
+  *   // if specified both with maxRequests and perMilliseconds
+  *   const http = rateLimit(axios.create(), { maxRequests: 2, perMilliseconds: 1000, maxRPS: 2 })
+ *    http.getMaxRPS() // 2
+  *   http.get('https://example.com/api/v1/users.json?page=1') // will perform immediately
+  *   http.get('https://example.com/api/v1/users.json?page=2') // will perform immediately
+  *   http.get('https://example.com/api/v1/users.json?page=3') // will perform after 1 second from the first one
+  *   http.setMaxRPS(3)
+  *   http.getMaxRPS() // 3
+  *   http.setRateLimitOptions({ maxRequests: 6, perMilliseconds: 150 }) // same options as constructor
+  *
+  * @param {Object} axios axios instance
+  * @param {Object} options options for rate limit, available for live update
+  * @param {Number} options.maxRequests max requests to perform concurrently in given amount of time.
+  * @param {Number} options.perMilliseconds amount of time to limit concurrent requests.
+  * @returns {Object} axios instance with interceptors added
+  */
+export default function axiosRateLimit(
     axiosInstance: AxiosInstance,
-    options: { maxRequests: number, perMilliseconds: number },
+    options: rateLimitOPtions
 ): RateLimitedAxiosInstance;
-
-export = axiosRateLimit;


### PR DESCRIPTION
fixes https://github.com/aishek/axios-rate-limit/issues/20
- preserve export default for `import rateLimit from 'axios-rate-limit';`
- add interface export for RateLimitedAxiosInstance - now you can do `import rateLimit, { RateLimitedAxiosInstance } from 'axios-rate-limit';`
- added the prototype function calls, so that typescript does not complain when you use the example `http.getMaxRPS() `